### PR TITLE
Fix database entity

### DIFF
--- a/postgres_declare/entities/database_content.py
+++ b/postgres_declare/entities/database_content.py
@@ -14,35 +14,28 @@ class DatabaseContent(DatabaseEntity):
         self,
         name: str,
         sqlalchemy_base: Type[DeclarativeBase],
-        databases: Sequence[Database],
+        database: Database,
         schemas: Sequence[Schema] | None = None,
         depends_on: Sequence[Entity] | None = None,
         check_if_exists: bool | None = None,
     ):
-        super().__init__(name=name, depends_on=depends_on, databases=databases, check_if_exists=check_if_exists)
+        super().__init__(name=name, depends_on=depends_on, database=database, check_if_exists=check_if_exists)
         self.base = sqlalchemy_base
         # schemas doesn't do anything since __table_args__ in sqlalchemy defines the schema
         # BUT it helps to have it as a dependency here to remind the user to make schemas they intend to use
         self.schemas = schemas
 
     def _create(self) -> None:
-        for db in self.databases:
-            self.base.metadata.create_all(db.db_engine())
+        self.base.metadata.create_all(self.database.db_engine())
 
     def _exists(self) -> bool:
-        tables_in_db = []
-        for db in self.databases:
-            inspector: Inspector = inspect(db.db_engine())
-            tables_in_db.append(
-                all(
-                    [
-                        inspector.has_table(table_name=table.name, schema=table.schema)
-                        for table in self.base.metadata.tables.values()
-                    ]
-                )
-            )
-        return all(tables_in_db)
+        inspector: Inspector = inspect(self.database.db_engine())
+        return all(
+            [
+                inspector.has_table(table_name=table.name, schema=table.schema)
+                for table in self.base.metadata.tables.values()
+            ]
+        )
 
     def _drop(self) -> None:
-        for db in self.databases:
-            self.base.metadata.drop_all(db.db_engine())
+        self.base.metadata.drop_all(self.database.db_engine())

--- a/postgres_declare/entities/database_entity.py
+++ b/postgres_declare/entities/database_entity.py
@@ -9,25 +9,22 @@ class DatabaseEntity(Entity):
     def __init__(
         self,
         name: str,
-        databases: Sequence[Database],
+        database: Database,
         depends_on: Sequence[Entity] | None = None,
         check_if_exists: bool | None = None,
     ):
-        self.databases: Sequence[Database] = databases
+        self.database = database
         super().__init__(name=name, depends_on=depends_on, check_if_exists=check_if_exists)
 
 
 class DatabaseSqlEntity(SQLMixin, DatabaseEntity):
     # TODO maybe inherit from grantable, maybe do it per entity?
     def _create(self) -> None:
-        for db in self.databases:
-            self._commit_sql(engine=db.db_engine(), statements=self._create_statements())
+        self._commit_sql(engine=self.database.db_engine(), statements=self._create_statements())
 
     def _exists(self) -> bool:
-        return all(
-            [self._fetch_sql(engine=db.db_engine(), statement=self._exists_statement())[0][0] for db in self.databases]
-        )
+        rows = self._fetch_sql(engine=self.database.db_engine(), statement=self._exists_statement())
+        return rows[0][0]  # type: ignore
 
     def _drop(self) -> None:
-        for db in self.databases:
-            self._commit_sql(engine=db.db_engine(), statements=self._drop_statements())
+        self._commit_sql(engine=self.database.db_engine(), statements=self._drop_statements())

--- a/postgres_declare/entities/database_entity.py
+++ b/postgres_declare/entities/database_entity.py
@@ -16,6 +16,18 @@ class DatabaseEntity(Entity):
         self.database = database
         super().__init__(name=name, depends_on=depends_on, check_if_exists=check_if_exists)
 
+    def __hash__(self) -> int:
+        return hash((self.name, self.__class__.__name__, self.database.name))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return (self.name, self.__class__.__name__, self.database.name) == (
+            other.name,
+            other.__class__.__name__,
+            other.database.name,
+        )
+
 
 class DatabaseSqlEntity(SQLMixin, DatabaseEntity):
     # TODO maybe inherit from grantable, maybe do it per entity?

--- a/postgres_declare/entities/entity.py
+++ b/postgres_declare/entities/entity.py
@@ -43,6 +43,7 @@ class Entity(ABC):
 
     @classmethod
     def _register(cls, entity: "Entity") -> None:
+        # TODO add code to make sure there are no duplicate entities
         cls.entities.append(entity)
 
     @classmethod
@@ -50,10 +51,7 @@ class Entity(ABC):
         if cls._engine:
             return cls._engine
         else:
-            raise NoEngineError(
-                "There is no SQLAlchemy Engine present. `Base._engine` must have "
-                "a valid engine. This should be passed via the `_create_all` method."
-            )
+            raise NoEngineError("There is no SQLAlchemy Engine present. `Base._engine` must have " "a valid engine.")
 
     @abstractmethod
     def _create(self) -> None:

--- a/postgres_declare/entities/schema.py
+++ b/postgres_declare/entities/schema.py
@@ -12,13 +12,13 @@ class Schema(DatabaseSqlEntity):
     def __init__(
         self,
         name: str,
-        databases: Sequence[Database],
+        database: Database,
         depends_on: Sequence[Entity] | None = None,
         check_if_exists: bool | None = None,
         owner: Role | None = None,
     ):
         self.owner = owner
-        super().__init__(name=name, depends_on=depends_on, databases=databases, check_if_exists=check_if_exists)
+        super().__init__(name=name, depends_on=depends_on, database=database, check_if_exists=check_if_exists)
 
     def _create_statements(self) -> Sequence[TextClause]:
         statement = f"CREATE SCHEMA {self.name}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ schema_name = "simple_schema"
 
 @pytest.fixture(scope="module")
 def simple_schema(entity: Entity, simple_db: Database) -> YieldFixture[Schema]:
-    yield Schema(name=schema_name, databases=[simple_db])
+    yield Schema(name=schema_name, database=simple_db)
 
 
 class MyBase(DeclarativeBase):
@@ -70,6 +70,4 @@ class FancyTable(MyBase):
 
 @pytest.fixture(scope="module")
 def simple_db_content(entity: Entity, simple_db: Database, simple_schema: Schema) -> YieldFixture[DatabaseContent]:
-    yield DatabaseContent(
-        name="simple_db_content", databases=[simple_db], schemas=[simple_schema], sqlalchemy_base=MyBase
-    )
+    yield DatabaseContent(name="simple_db_content", database=simple_db, schemas=[simple_schema], sqlalchemy_base=MyBase)

--- a/tests/it/test_schema.py
+++ b/tests/it/test_schema.py
@@ -33,6 +33,6 @@ def test_dependency_inputs(engine: Engine) -> None:
     Entity.check_if_any_exist = False
     existing_role = Role(name="existing_role_for_schema")
     existing_db = Database(name="foobar")
-    Schema(name="has_owner", databases=[existing_db], owner=existing_role)
+    Schema(name="has_owner", database=existing_db, owner=existing_role)
     Base.create_all(engine)
     Base.drop_all()

--- a/tests/unit/test_database_entity.py
+++ b/tests/unit/test_database_entity.py
@@ -8,7 +8,7 @@ class MockDatabaseEntity(DatabaseEntity):
         pass
 
     def _exists(self) -> bool:
-        pass
+        return True
 
     def _drop(self) -> None:
         pass

--- a/tests/unit/test_database_entity.py
+++ b/tests/unit/test_database_entity.py
@@ -1,0 +1,37 @@
+from postgres_declare.entities.database import Database
+from postgres_declare.entities.database_entity import DatabaseEntity
+from postgres_declare.entities.entity import Entity
+
+
+class MockDatabaseEntity(DatabaseEntity):
+    def _create(self) -> None:
+        pass
+
+    def _exists(self) -> bool:
+        pass
+
+    def _drop(self) -> None:
+        pass
+
+
+def test_database_entity_hash_works(entity: Entity) -> None:
+    entity.entities = []
+    db1 = Database("db1")
+    db2 = Database("db2")
+    mde1 = MockDatabaseEntity("mde1", database=db1)
+    mde2 = MockDatabaseEntity("mde1", database=db2)
+    mde3 = MockDatabaseEntity("mde1", database=db1)
+    myset = {mde1, mde2, mde3}
+    assert len(myset) == 2
+
+
+def test_database_entity_eq_works(entity: Entity) -> None:
+    entity.entities = []
+    db1 = Database("db1")
+    db2 = Database("db2")
+    mde1 = MockDatabaseEntity("mde1", database=db1)
+    mde2 = MockDatabaseEntity("mde1", database=db2)
+    mde3 = MockDatabaseEntity("mde1", database=db1)
+
+    assert mde1 == mde3
+    assert mde1 != mde2


### PR DESCRIPTION
For `DatabaseEntity`, changes the `databases` argument to `database` and changes the type from `Sequence[Database]` to just `Database`. Updates tests accordingly, and adds `__hash__` and `__eq__` functions for non-cluster entities as well (and tests for that).